### PR TITLE
fix test failures on big-endian systems

### DIFF
--- a/cbits/sha3.c
+++ b/cbits/sha3.c
@@ -56,7 +56,7 @@ static inline void sha3_do_chunk(uint64_t state[25], uint64_t buf[], int bufsz)
 
 	/* merge buf with state */
 	for (i = 0; i < bufsz; i++)
-		state[i] ^= buf[i];
+		state[i] ^= le64_to_cpu(buf[i]);
 
 	/* run keccak rounds */
 	for (r = 0; r < KECCAK_NB_ROUNDS; r++) {
@@ -137,6 +137,8 @@ void sha3_update(struct sha3_ctx *ctx, uint8_t *data, uint32_t len)
 
 void sha3_finalize(struct sha3_ctx *ctx, uint8_t *out)
 {
+	uint64_t w[25];
+
 	/* add the 10*1 padding */
 	ctx->buf[ctx->bufindex++] = 1;
 	memset(ctx->buf + ctx->bufindex, 0, ctx->bufsz - ctx->bufindex);
@@ -146,5 +148,6 @@ void sha3_finalize(struct sha3_ctx *ctx, uint8_t *out)
 	sha3_do_chunk(ctx->state, (uint64_t *) ctx->buf, ctx->bufsz / 8);
 
 	/* output */
-	memcpy(out, ctx->state, ctx->hashlen);
+	cpu_to_le64_array(w, ctx->state, 25);
+	memcpy(out, w, ctx->hashlen);
 }

--- a/cbits/skein256.c
+++ b/cbits/skein256.c
@@ -174,6 +174,7 @@ void skein256_finalize(struct skein256_ctx *ctx, uint8_t *out)
 		x[j] = ctx->h[j];
 	/* threefish in counter mode, 0 for 1st 64 bytes, 1 for 2nd 64 bytes, .. */
 	for (i = 0; i*32 < outsize; i++) {
+		uint64_t w[4];
 		*((uint64_t *) ctx->buf) = cpu_to_le64(i);
 		SET_TYPE(ctx, FLAG_FIRST | FLAG_FINAL | FLAG_TYPE(TYPE_OUT));
 		skein256_do_chunk(ctx, (uint64_t *) ctx->buf, sizeof(uint64_t));
@@ -181,8 +182,8 @@ void skein256_finalize(struct skein256_ctx *ctx, uint8_t *out)
 		n = outsize - i * 32;
 		if (n >= 32) n = 32;
 
-		/* FIXME should be little endian array copy ? */
-		memcpy(out + i*32, ctx->h, n);
+		cpu_to_le64_array(w, ctx->h, 4);
+		memcpy(out + i*32, w, n);
 
 		/* restore h[0--4] */
 		for (j = 0; j < 4; j++)

--- a/cbits/skein512.c
+++ b/cbits/skein512.c
@@ -192,6 +192,7 @@ void skein512_finalize(struct skein512_ctx *ctx, uint8_t *out)
 		x[j] = ctx->h[j];
 	/* threefish in counter mode, 0 for 1st 64 bytes, 1 for 2nd 64 bytes, .. */
 	for (i = 0; i*64 < outsize; i++) {
+		uint64_t w[8];
 		*((uint64_t *) ctx->buf) = cpu_to_le64(i);
 		SET_TYPE(ctx, FLAG_FIRST | FLAG_FINAL | FLAG_TYPE(TYPE_OUT));
 		skein512_do_chunk(ctx, (uint64_t *) ctx->buf, sizeof(uint64_t));
@@ -199,8 +200,8 @@ void skein512_finalize(struct skein512_ctx *ctx, uint8_t *out)
 		n = outsize - i * 64;
 		if (n >= 64) n = 64;
 
-		/* FIXME should be little endian array copy ? */
-		memcpy(out + i*64, ctx->h, n);
+		cpu_to_le64_array(w, ctx->h, 8);
+		memcpy(out + i*64, w, n);
 
 		/* restore h[0--7] */
 		for (j = 0; j < 8; j++)


### PR DESCRIPTION
This fixes test failures on big-endian systems.  You can see failing test output here:

  https://launchpadlibrarian.net/134406777/buildlog_ubuntu-raring-powerpc.haskell-cryptohash_0.8.3-1build1_FAILEDTOBUILD.txt.gz

I've tested this on the current Ubuntu development branch, on both i386 and powerpc.
